### PR TITLE
Add usage rules and localization skill for LLM agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,9 +153,13 @@ Explicit keys can be used with the `::` syntax for more control to disambiguate 
 ~t"Valid: #{x :: Foo.bar()} != #{y :: foo_bar}"
 # => gettext("Valid: %{x} != %{y}", x: Foo.bar(), y: foo_bar)
 ```
-
+  
 ## Pluralization
 
 Gettext pluralization (`ngettext`, ...) is currently **not** supported. See open [issue #3](https://github.com/zebbra/gettext_sigils/issues/3).
+
+## Usage Rules
+
+GettextSigils ships with usage rules and skills for LLM coding agents (Claude Code, Cursor, Codex, etc.) via the [`usage_rules`](https://hexdocs.pm/usage_rules) library. See the [LLM guide](guides/llm.md) for setup instructions.
 
 <!-- MDOC -->

--- a/guides/llm.md
+++ b/guides/llm.md
@@ -1,0 +1,44 @@
+# LLM Agents
+
+GettextSigils ships with a `usage-rules.md` and optional skills that LLM agents (Claude Code, Cursor, Codex, etc.) can use to generate translatable code. The [`usage_rules`](https://hexdocs.pm/usage_rules) library distributes these to your agent automatically.
+
+## Setup
+
+[Install `usage_rules`](https://hexdocs.pm/usage_rules/readme.html), then add GettextSigils to your `usage_rules` config in `mix.exs`:
+
+```elixir
+defp usage_rules do
+  [
+    file: "AGENTS.md",
+    usage_rules: [
+      :gettext_sigils
+    ]
+  ]
+end
+```
+
+Run `mix usage_rules.sync` to generate or update your `AGENTS.md` file. This inlines the GettextSigils usage rules so your agent knows to use `~t` instead of fixed strings.
+
+## Skills
+
+GettextSigils ships optional skills that agents can discover and use. To install them, add a `skills` section:
+
+```elixir
+defp usage_rules do
+  [
+    file: "AGENTS.md",
+    usage_rules: [
+      :gettext_sigils
+    ],
+    skills: [
+      package_skills: [:gettext_sigils]
+    ]
+  ]
+end
+```
+
+Run `mix usage_rules.sync` again. This copies skills into your configured skills directory (`.claude/skills/` by default), where your agent can discover and use them.
+
+### `gettext-sigils-localization`
+
+Teaches agents how to systematically localize an application with `~t`. Covers replacing user-facing strings, using modifiers, and optionally extracting and translating `.po` files. ([source](https://github.com/zebbra/gettext_sigils/blob/main/usage-rules/skills/gettext-sigils-localization/SKILL.md))

--- a/mix.exs
+++ b/mix.exs
@@ -68,8 +68,16 @@ defmodule GettextSigils.MixProject do
 
   defp docs do
     [
-      main: "GettextSigils",
-      extras: ["README.md", "CHANGELOG.md"],
+      main: "readme",
+      source_ref: "v#{@version}",
+      extras: [
+        {"README.md", title: "Home"},
+        {"CHANGELOG.md", title: "Changelog"},
+        "guides/llm.md"
+      ],
+      groups_for_extras: [
+        Guides: Path.wildcard("guides/*.md")
+      ],
       groups_for_modules: []
     ]
   end
@@ -78,7 +86,7 @@ defmodule GettextSigils.MixProject do
     [
       name: "gettext_sigils",
       licenses: ["MIT"],
-      files: ~w(lib .formatter.exs mix.exs README.md LICENSE),
+      files: ~w(lib usage-rules.md usage-rules .formatter.exs mix.exs README.md LICENSE),
       links: %{
         "GitHub" => @github_url
       }

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -1,0 +1,71 @@
+# Using GettextSigils
+
+GettextSigils provides a `~t` sigil for Elixir's Gettext, replacing verbose `gettext`/`dgettext`/`pgettext` calls with concise, interpolation-aware syntax. All processing is compile-time macro expansion.
+
+**VERY IMPORTANT:** If the user has `GettextSigils` installed, they expect you to use the `~t` sigil instead of fixed strings in all user-facing parts of the application (eg. Phoenix HEEx templates, flash messages, etc.). See the *Localizing Projects* section below.
+
+## Setup
+
+Replace `use Gettext` with `use GettextSigils` in modules that need translations:
+
+```elixir
+# replace this
+use Gettext, backend: MyApp.Gettext
+# with this
+use GettextSigils, backend: MyApp.Gettext
+```
+
+**NOTE:** This might have been done already in the project by the user. Search for `use GettextSigils` to verify (and note additional options, eg. `:domain`, `:context` and `:modifiers`).
+
+## The `~t` Sigil
+
+```elixir
+~t"Hello, World!"
+# => gettext("Hello, World!")
+
+~t"Hello, #{user.name}!"
+# => gettext("Hello, %{user_name}!", user_name: user.name)
+```
+
+- Elixir `#{}` interpolations are automatically converted to Gettext `%{key}` placeholders
+- Keys are derived from the expression (see Key Derivation below)
+- All sigil delimiters work: `~t"..."`, `~t[...]`, `~t(...)`, etc. Use double quotes by default, unless the translated string itself contains double quotes.
+
+## Key Derivation
+
+- Keys are automatically derived from the expression, eg. `name` → `name`, `fruit.name` → `fruit_name`, `String.upcase(x)` → `string_upcase` (other expressions: `var`)
+- Duplicate keys with identical expressions are allowed and merged
+- Duplicate keys with different expressions raise `ArgumentError`
+- Use explicit keys (`#{key :: expr}`) to disambiguate interpolation keys or to 
+
+## Domain, Context & Modifiers
+
+- Default domain/context (when using `~t` without modifiers) are defined under the `sigils:` key when using `GettextSigils`
+- Modifiers allow overriding domain/context per `~t` sigil call
+
+```elixir
+use GettextSigils,
+  backend: MyApp.Gettext,
+  # domain: "default",
+  # context: nil
+  sigils: [
+    modifiers: [
+      e: [domain: "errors"],
+      m: [context: inspect(__MODULE__)]
+    ]
+  ]
+
+~t"Welcome"       # domain: "default", context: nil
+~t"Not found"e    # domain: "errors",  context: nil
+~t"Hello"m        # domain: "default", context: "MyApp.SomeModule"
+~t"Oops"em        # domain: "errors",  context: "MyApp.SomeModule"
+```
+
+## Localizing Projects
+
+When generating code, you MUST NOT use fixed strings — use the `~t` sigil instead. If you have the `/gettext-sigils-localization` skill installed, use it to generate localized code. If you do not have this skill, read and follow `deps/gettext_sigils/usage-rules/skills/gettext-sigils-localization/SKILL.md`.
+
+## Limitations
+
+- **Pluralization** (`ngettext`) is not supported yes, use the `ngettext/5` macro instead
+- **Runtime strings** cannot be translated — `~t` is compile-time only (expecpt for `~t` interpolations)

--- a/usage-rules/skills/gettext-sigils-localization/SKILL.md
+++ b/usage-rules/skills/gettext-sigils-localization/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: gettext-sigils-localization
+description: Use when generating or modifying user-facing strings in an Elixir app that has GettextSigils installed. Triggered when writing code with user-visible text (flash messages, HEEx templates, CLI output, error messages) or when user asks to localize, translate, or add i18n.
+---
+
+# Localizing Applications with GettextSigils
+
+## Overview
+
+When GettextSigils is installed, all user-facing strings should use the `~t` sigil to make them translatable. This is a two-phase process:
+
+1. **Write translatable code** (always) — use `~t` instead of fixed strings
+2. **Generate translations** (optional, on request) — extract and fill `.po` files
+
+## When to Use
+
+- Writing or modifying code that contains user-facing strings
+- User asks to translate, localize, or internationalize the app
+- Replacing hardcoded strings with gettext calls
+
+**Not for:** locale routing setup or language switcher components.
+
+## Phase 1: Write Translatable Code
+
+### Explore the Gettext Setup
+
+1. Find where `use GettextSigils` is called — in Phoenix apps check `<app>_web.ex` shared helpers, otherwise search `lib/` modules
+2. Note the configured `sigils:` options — especially `:domain`, `:context`, and `:modifiers`
+
+### Replace Strings with `~t`
+
+| Location | Pattern |
+|----------|---------|
+| HEEx text | `Listing Posts` → `{~t"Listing Posts"}` |
+| HEEx attribute | `label="Title"` → `label={~t"Title"}` |
+| Elixir string | `"Post saved"` → `~t"Post saved"` |
+| Interpolation | `"Hello, #{name}"` → `~t"Hello, #{name}"` |
+
+Use modifiers where configured (e.g. `~t"Not found"e` for the errors domain). Check the `sigils:` options for available modifiers. If unsure, ask the user what modifiers to use.
+
+**Skip:** module names, struct keys, protocol/behaviour identifiers, programmatic strings (config keys, etc.), Logger output, and mix task terminal output. In Phoenix apps also skip: routes, CSS classes, `id`/`name`/`phx-*` attributes. Only translate CLI output if the CLI is the app's main user interface.
+
+### Localizing Dates, Numbers and other Data
+
+When writing code that formats dates, times, numbers, or currencies for display, do NOT use hardcoded format strings (e.g., `Calendar.strftime/2`, `NaiveDateTime.to_string/1`, fixed format patterns). These are locale-sensitive and must be treated like translatable strings.
+
+Instead: check for existing project helpers (`format_date/1`, etc.) or a CLDR backend. If neither exists, **ask the user** how they want locale-sensitive data formatted before proceeding — suggest adding `ex_cldr` and relevant plugins (`ex_cldr_dates_times`, `ex_cldr_numbers`, etc.).
+
+### After Writing Translatable Code
+
+After completing Phase 1, ask the user: "Would you like me to extract and generate translations for any locales?" Do not silently skip Phase 2.
+
+## Phase 2: Generate Translations
+
+Only proceed when the user confirms they want translations generated.
+
+1. Identify configured locales in `config/config.exs` and existing translations in `priv/gettext/`
+2. Run `mix gettext.extract --merge --sync` to extract new strings and merge with existing translations
+3. **Before filling in translations**, ask the user: "Should I mark the generated translations as fuzzy?" Wait for their answer before proceeding.
+4. Fill empty `msgstr` values in `priv/gettext/<locale>/LC_MESSAGES/<domain>.po`, applying the user's fuzzy preference
+5. Run `mix gettext.extract --check-up-to-date` to confirm everything is up to date
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Using `gettext()` instead of `~t` | GettextSigils replaces verbose gettext calls — use `~t` consistently |
+| Ignoring configured modifiers | Check `sigils: [modifiers: [...]]` in the `use GettextSigils` call and apply where appropriate |
+| Translating programmatic strings | Only translate user-visible text, not config keys, identifiers, or log messages |
+| Generating `.po` files without being asked | Phase 2 is opt-in — ask the user first, then proceed if confirmed |
+| Forgetting `--sync` flag | Without `--sync`, removed strings stay in .po files |
+| Using hardcoded date/time/number formats | These are locale-sensitive — ask the user about formatting strategy before using fixed format strings |
+| Silently skipping Phase 2 | Always ask the user if they want translations generated after writing translatable code |
+| Filling translations without asking about fuzzy | Always ask the user whether to mark generated translations as fuzzy **before** writing `msgstr` values |


### PR DESCRIPTION
## Summary
- Add `usage-rules.md` with concise `~t` sigil reference for LLM agents
- Add `gettext-sigils-localization` skill teaching agents how to systematically localize applications (two-phase: translatable code always, `.po` generation on request)
- Add `guides/llm.md` explaining how to configure `usage_rules` to distribute rules and skills
- Update `mix.exs` to include `usage-rules` files in hex package and add guide to HexDocs
- Add "Usage Rules" section to README linking to the guide

Fixes #13

## Test plan
- [x] Verify `mix docs` generates correctly with the new guide
- [x] Verify hex package includes `usage-rules.md` and `usage-rules/` directory
- [x] Test `usage_rules` integration: add `:gettext_sigils` to a consuming project's config and run `mix usage_rules.sync`
- [x] Test skill installation via `package_skills: [:gettext_sigils]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)