### PR TITLE
feat: deprecate separator-based pluralization in favor of shared message

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@
 - **Modifiers**: Single-letter suffixes override domain/context per-call (e.g. `~t"Error"e` uses the `errors` domain)
 - **Modifier composition**: Multiple modifiers apply left-to-right, last wins (`~t"msg"em` ≠ `~t"msg"me`)
 - **Compile-time only**: All transformation happens via macros — zero runtime overhead
-- **Pluralization**: `~t"One item||#{count} items"N` — the `N` modifier splits on separator, emits `dpngettext/6`
+- **Pluralization**: `~t"#{count} item(s)"N` — the `N` modifier uses the message as both `msgid` and `msgid_plural`, emits `dpngettext/6`
 
 ### Architecture
 

--- a/README.md
+++ b/README.md
@@ -167,45 +167,67 @@ Explicit keys can be used with the `::` syntax for more control to disambiguate 
   
 ## Pluralization
 
-Use the `N` modifier and the `||` separator to split singular and plural forms. The `count` binding determines which form Gettext selects at runtime:
+Use the `N` modifier for pluralization. The `count` binding determines which form Gettext selects at runtime:
 
 ```elixir
-~t"One error||#{count} errors"N
-# with count = 1 => "One error"
-# with count = 3 => "3 errors"
+~t"#{count} error(s)"N
+# with count = 1 => "1 error(s)"  (untranslated fallback)
+# with count = 3 => "3 error(s)"  (untranslated fallback)
+```
+
+Under the hood, the sigil uses the same message as both `msgid` and `msgid_plural`:
+
+```elixir
+~t"#{count} error(s)"N
+# =>
+dpngettext("default", nil, "%{count} error(s)", "%{count} error(s)", count)
+```
+
+Translators provide distinct singular/plural forms in the `.po` file:
+
+```pot
+msgid "%{count} error(s)"
+msgid_plural "%{count} error(s)"
+msgstr[0] "One error"
+msgstr[1] "%{count} errors"
+```
+
+This enables progressive adoption without changing the message:
+
+```elixir
+# plain string (no gettext)
+"#{count} error(s)"
+
+# gettext without pluralization
+~t"#{count} error(s)"
+
+# gettext with pluralization
+~t"#{count} error(s)"N
 ```
 
 You can use explicit key syntax to bind `count` to an arbitrary expression:
 
 ```elixir
-~t"One user||#{count :: length(users)} users"N
+~t"#{count :: length(users)} user(s)"N
 ```
 
-Under the hood, the sigil maps to Gettext's `dpngettext/6`:
+`count` must appear as a binding. Using `N` without a `count` binding raises an `ArgumentError`. Without the `N` modifier, the message is treated as a regular (non-plural) translation.
+
+The `N` modifier can be combined with other modifiers: `~t"#{count} error(s)"eN` uses the `errors` domain.
+
+### Separator-based pluralization
+
+> **Deprecated:** Using a separator (`||`) to split singular and plural forms is deprecated and will be removed in a future version.
 
 ```elixir
+# deprecated — migrate to shared message
 ~t"One error||#{count} errors"N
-# =>
-dpngettext("default", nil, "One error", "%{count} errors", count)
+
+# use instead
+~t"#{count} error(s)"N
 ```
 
-`count` must appear as a binding in at least one of the singular or plural parts. Using `N` without a separator in the message raises an `ArgumentError`. Without the `N` modifier, `||` is treated as literal text.
-
-The `N` modifier can be combined with other modifiers: `~t"One error||#{count} errors"eN` uses the `errors` domain.
-
-### Custom separator
-
-The separator defaults to `||` (double pipe). You can override it globally via application config or per-module:
-
-```elixir
-# Application config
-config :gettext_sigils, pluralization: [separator: "✂️"]
-
-# Per-module
-use GettextSigils,
-  backend: MyApp.Gettext,
-  sigils: [pluralization: [separator: "<plural>"]]
-```
+The separator defaults to `||` (double pipe). Custom separators can be configured globally or per-module, but this feature is also deprecated along with separator-based pluralization.
 
 ## Usage Rules
 

--- a/lib/gettext_sigils/pluralization.ex
+++ b/lib/gettext_sigils/pluralization.ex
@@ -1,38 +1,33 @@
 defmodule GettextSigils.Pluralization do
   @moduledoc ~S"""
-  Splits a parsed `~t` sigil into singular and plural forms for Gettext pluralization.
+  Handles pluralization for the `~t` sigil's `N` modifier.
 
-  Pluralization is activated by the `N` modifier. When present, the message is
-  split on the separator into a singular and a plural form, and the `:count`
-  binding is extracted to be passed as the `n` argument to `dpngettext/6`.
-
-  ## Separator
-
-  The default separator is `||` (double pipe). It can be changed per-module or
-  globally:
-
-  ```elixir
-  # config/config.exs
-  config :gettext_sigils, pluralization: [separator: "✂️"]
-
-  # per-module
-  use GettextSigils,
-    backend: MyApp.Gettext,
-    sigils: [pluralization: [separator: "✂️"]]
-  ```
+  When the `N` modifier is present, the message is used as both `msgid` and
+  `msgid_plural`, and the `:count` binding is extracted as the `n` argument
+  to `dpngettext/6`.
 
   ## Examples
 
-  ```elixir
-  ~t"One error||#{count} errors"N
-  #=> dpngettext("default", nil, "One error", "%{count} errors", count)
+      ~t"#{count} error(s)"N
+      #=> dpngettext("default", nil, "%{count} error(s)", "%{count} error(s)", count)
 
-  ~t"One user||#{count :: length(users)} users"N
-  #=> dpngettext("default", nil, "One user", "%{count} users", length(users))
-  ```
+  The resulting PO entry can be translated with distinct singular/plural forms:
 
-  The `count` binding must appear in at least one part (singular or plural).
-  It is removed from the bindings and only passed as the `n` argument.
+      msgid "%{count} error(s)"
+      msgid_plural "%{count} error(s)"
+      msgstr[0] "One error"
+      msgstr[1] "%{count} errors"
+
+  ## Deprecated: Separator-based pluralization
+
+  Using a separator (`||`) to split singular/plural forms is deprecated and
+  will be removed in a future version. Migrate to the shared-message approach:
+
+      # deprecated
+      ~t"One error||#{count} errors"N
+
+      # use instead
+      ~t"#{count} error(s)"N
   """
 
   @type singular() :: {binary(), Keyword.t()}
@@ -42,12 +37,18 @@ defmodule GettextSigils.Pluralization do
   def split!({msgid, bindings}, separator) do
     case String.split(msgid, separator) do
       [_single] ->
-        raise ArgumentError,
-              "the N modifier requires a separator #{inspect(separator)} in the message, but none was found"
+        {count, remaining} = extract_count!(bindings)
+        {msgid, msgid, count, remaining}
 
       [singular, plural] ->
-        {count, remaining_bindings} = extract_count!(bindings)
-        {singular, plural, count, remaining_bindings}
+        IO.warn(
+          "using a separator (#{inspect(separator)}) for pluralization in ~t sigil is deprecated, " <>
+            ~s'use a shared message instead, e.g. ~t"\#{count} item(s)"N. ' <>
+            "See https://github.com/zebbra/gettext_sigils/issues/20"
+        )
+
+        {count, remaining} = extract_count!(bindings)
+        {singular, plural, count, remaining}
 
       _parts ->
         raise ArgumentError,

--- a/test/gettext_sigils/domain_context_test.exs
+++ b/test/gettext_sigils/domain_context_test.exs
@@ -10,7 +10,7 @@ defmodule GettextSigils.DomainContextTest do
 
     test "plural uses default domain" do
       count = 2
-      assert ~t"One item||#{count} items"N == "default: 2 items"
+      assert ~t"#{count} item(s)"N == "default: 2 item(s)"
     end
   end
 

--- a/test/gettext_sigils/pluralization_test.exs
+++ b/test/gettext_sigils/pluralization_test.exs
@@ -1,6 +1,8 @@
 defmodule GettextSigils.PluralizationTest do
   use ExUnit.Case, async: true
 
+  import ExUnit.CaptureIO
+
   alias GettextSigils.Interpolation
   alias GettextSigils.Pluralization
 
@@ -14,49 +16,65 @@ defmodule GettextSigils.PluralizationTest do
     end
   end
 
-  describe "split!" do
+  describe "split! (deprecated separator)" do
     test "splits on separator and extracts count" do
       count = 3
-      assert split_parsed!("One error||#{count} errors") == {"One error", "%{count} errors", 3, []}
+
+      capture_io(:stderr, fn ->
+        assert split_parsed!("One error||#{count} errors") == {"One error", "%{count} errors", 3, []}
+      end)
     end
 
     test "removes count from bindings, keeps others" do
       count = 2
       name = "validation"
 
-      {_msgid, _msgid_plural, _count, bindings} =
-        split_parsed!("One #{name} error||#{count} #{name} errors")
+      capture_io(:stderr, fn ->
+        {_msgid, _msgid_plural, _count, bindings} =
+          split_parsed!("One #{name} error||#{count} #{name} errors")
 
-      assert bindings == [name: "validation"]
+        assert bindings == [name: "validation"]
+      end)
     end
 
     test "count in singular part only" do
       count = 1
-      assert split_parsed!("#{count} error||many errors") == {"%{count} error", "many errors", 1, []}
+
+      capture_io(:stderr, fn ->
+        assert split_parsed!("#{count} error||many errors") ==
+                 {"%{count} error", "many errors", 1, []}
+      end)
     end
 
     test "count via explicit key syntax" do
       users = [1, 2, 3]
 
-      assert split_parsed!("One user||#{count :: length(users)} users") ==
-               {"One user", "%{count} users", 3, []}
+      capture_io(:stderr, fn ->
+        assert split_parsed!("One user||#{count :: length(users)} users") ==
+                 {"One user", "%{count} users", 3, []}
+      end)
     end
   end
 
-  describe "custom separator" do
+  describe "custom separator (deprecated)" do
     test "splits on custom separator" do
       count = 3
 
-      assert split_parsed!("One error‖#{count} errors", "‖") ==
-               {"One error", "%{count} errors", 3, []}
+      capture_io(:stderr, fn ->
+        assert split_parsed!("One error‖#{count} errors", "‖") ==
+                 {"One error", "%{count} errors", 3, []}
+      end)
     end
   end
 
   describe "errors" do
-    test "raises when separator is missing" do
-      assert_raise ArgumentError, ~r/the N modifier requires a separator/, fn ->
+    test "uses shared message when separator is missing" do
+      {msgid, msgid_plural, _count, bindings} =
         Pluralization.split!({"No separator here", [count: quote(do: count)]}, @separator)
-      end
+
+      assert msgid == "No separator here"
+      assert msgid_plural == "No separator here"
+      assert bindings == []
     end
 
     test "raises on multiple separators" do
@@ -67,7 +85,58 @@ defmodule GettextSigils.PluralizationTest do
 
     test "raises when count binding is missing" do
       assert_raise ArgumentError, ~r/requires a "count" binding/, fn ->
-        Pluralization.split!({"One error||many errors", []}, @separator)
+        Pluralization.split!({"no count here", []}, @separator)
+      end
+    end
+  end
+
+  describe "deprecation warnings" do
+    test "emits warning when using separator" do
+      warning =
+        capture_io(:stderr, fn ->
+          assert Pluralization.split!({"One error||%{count} errors", [count: 3]}, "||") ==
+                   {"One error", "%{count} errors", 3, []}
+        end)
+
+      assert warning =~ "using a separator"
+      assert warning =~ "deprecated"
+    end
+
+    test "no warning for shared message" do
+      warning =
+        capture_io(:stderr, fn ->
+          assert Pluralization.split!({"%{count} error(s)", [count: 3]}, "||") ==
+                   {"%{count} error(s)", "%{count} error(s)", 3, []}
+        end)
+
+      assert warning == ""
+    end
+  end
+
+  describe "shared message (no separator)" do
+    test "uses msgid as both singular and plural" do
+      count = 3
+      assert split_parsed!("#{count} error(s)") == {"%{count} error(s)", "%{count} error(s)", 3, []}
+    end
+
+    test "preserves other bindings" do
+      count = 2
+      name = "validation"
+
+      assert split_parsed!("#{count} #{name} error(s)") ==
+               {"%{count} %{name} error(s)", "%{count} %{name} error(s)", 2, [name: "validation"]}
+    end
+
+    test "count via explicit key syntax" do
+      users = [1, 2, 3]
+
+      assert split_parsed!("#{count :: length(users)} user(s)") ==
+               {"%{count} user(s)", "%{count} user(s)", 3, []}
+    end
+
+    test "raises when count binding is missing" do
+      assert_raise ArgumentError, ~r/requires a "count" binding/, fn ->
+        Pluralization.split!({"no count here", []}, "||")
       end
     end
   end

--- a/test/gettext_sigils_test.exs
+++ b/test/gettext_sigils_test.exs
@@ -12,6 +12,8 @@ defmodule GettextSigilsTest do
       ]
     ]
 
+  import ExUnit.CaptureIO
+
   alias GettextSigilsTest.GettextTest
 
   describe "using the module" do
@@ -41,53 +43,46 @@ defmodule GettextSigilsTest do
     assert GettextTest.without_modifiers() == "translated without modifiers"
     assert GettextTest.with_modifiers() == "translated with modifiers"
     assert GettextTest.with_interpolation("interpolation") == "translated with interpolation"
-    assert GettextTest.with_pluralization(5) == "High 5!"
+    assert GettextTest.with_pluralization(1) == "One item"
+    assert GettextTest.with_pluralization(5) == "5 items"
   end
 
   describe "pluralization" do
     test "plural message with count" do
-      assert ~t"One error||#{count :: 1} errors"N == "frontend: One error"
-      assert ~t"One error||#{count :: 3} errors"N == "frontend: 3 errors"
+      assert ~t"#{count :: 1} error(s)"N == "frontend: 1 error(s)"
+      assert ~t"#{count :: 3} error(s)"N == "frontend: 3 error(s)"
     end
 
-    test "plural with interpolations in both parts" do
+    test "plural with additional bindings" do
       count = 2
       name = "validation"
-      assert ~t"One #{name} error||#{count} #{name} errors"N == "frontend: 2 validation errors"
+      assert ~t"#{count} #{name} error(s)"N == "frontend: 2 validation error(s)"
     end
 
     test "plural with count via explicit key" do
       users = [1, 2, 3]
-      assert ~t"One user||#{count :: length(users)} users"N == "frontend: 3 users"
+      assert ~t"#{count :: length(users)} user(s)"N == "frontend: 3 user(s)"
     end
 
     test "plural with modifiers" do
       count = 5
-      assert ~t"One error||#{count} errors"eN == "errors: 5 errors"
+      assert ~t"#{count} error(s)"eN == "errors: 5 error(s)"
     end
 
     test "separator is treated as literal without N modifier" do
       assert ~t"literal || pipe" == "frontend: literal || pipe"
     end
-  end
-end
 
-defmodule GettextSigilsTest.CustomSeparatorTest do
-  @moduledoc false
-  use ExUnit.Case, async: false
+    test "deprecated separator emits warning at runtime" do
+      warning =
+        capture_io(:stderr, fn ->
+          assert GettextSigils.Pluralization.split!(
+                   {"One error||%{count} errors", [count: 3]},
+                   "||"
+                 ) == {"One error", "%{count} errors", 3, []}
+        end)
 
-  describe "per-use custom separator" do
-    use GettextSigils,
-      backend: GettextSigilsTest.DummyGettext,
-      sigils: [pluralization: [separator: "✂️"]]
-
-    test "splits on custom separator" do
-      count = 3
-      assert ~t"One error✂️#{count} errors"N == "default: 3 errors"
-    end
-
-    test "does not split on default separator when custom is set" do
-      assert ~t"literal || pipe" == "default: literal || pipe"
+      assert warning =~ "is deprecated, use a shared message instead"
     end
   end
 end

--- a/test/support/gettext.ex
+++ b/test/support/gettext.ex
@@ -22,5 +22,5 @@ defmodule GettextSigilsTest.GettextTest do
   def without_modifiers, do: ~t"without modifiers"
   def with_modifiers, do: ~t"with modifiers"em
   def with_interpolation(i), do: ~t"with #{i}"
-  def with_pluralization(count), do: ~t"One||High #{count}!"N
+  def with_pluralization(count), do: ~t"#{count} item(s)"N
 end

--- a/test/support/gettext/en/LC_MESSAGES/example.po
+++ b/test/support/gettext/en/LC_MESSAGES/example.po
@@ -20,3 +20,10 @@ msgstr "translated without modifiers"
 #, elixir-autogen, elixir-format
 msgid "with %{i}"
 msgstr "translated with %{i}"
+
+#: test/support/gettext.ex:25
+#, elixir-autogen, elixir-format
+msgid "%{count} item(s)"
+msgid_plural "%{count} item(s)"
+msgstr[0] "One item"
+msgstr[1] "%{count} items"

--- a/test/support/gettext/example.pot
+++ b/test/support/gettext/example.pot
@@ -15,3 +15,10 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "with %{i}"
 msgstr ""
+
+#: test/support/gettext.ex:25
+#, elixir-autogen, elixir-format
+msgid "%{count} item(s)"
+msgid_plural "%{count} item(s)"
+msgstr[0] ""
+msgstr[1] ""

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -67,17 +67,17 @@ When generating code, you MUST NOT use fixed strings — use the `~t` sigil inst
 
 ## Pluralization
 
-Use the `N` modifier with `||` separator to split singular/plural forms:
+Use the `N` modifier for pluralization. The same message is used as both `msgid` and `msgid_plural`:
 
 ```elixir
-~t"One item||#{count} items"N
-# => dpngettext("default", nil, "One item", "%{count} items", count)
+~t"#{count} item(s)"N
+# => dpngettext("default", nil, "%{count} item(s)", "%{count} item(s)", count)
 ```
 
-- `count` must appear as a binding in at least one part (singular or plural)
+- `count` must appear as a binding
 - Bind `count` to an arbitrary expression with explicit key syntax: `#{count :: length(users)}`
-- Combine with other modifiers: `~t"One error||#{count} errors"eN` (uses `errors` domain)
-- Custom separator via app config (`config :gettext_sigils, pluralization: [separator: "✂️"]`) or per-module (`sigils: [pluralization: [separator: "✂️"]]`)
+- Combine with other modifiers: `~t"#{count} error(s)"eN` (uses `errors` domain)
+- Translators provide distinct singular/plural forms in `.po` files
 
 ## Limitations
 


### PR DESCRIPTION
The N modifier now uses the message as both msgid and msgid_plural, enabling simpler pluralization like ~t"#{count} error(s)"N.

The separator-based approach (~t"One||Many"N) still works but emits a compile-time deprecation warning.

Closes #20