### PR TITLE
Pluralize binding key

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,12 +167,26 @@ Explicit keys can be used with the `=` syntax for more control to disambiguate b
 
 ## Pluralization
 
-Use the `N` modifier for pluralization. The `count` binding determines which form Gettext selects at runtime:
+Use the `N` modifier for pluralization. With multiple bindings, the plural binding must be named `count`:
 
 ```elixir
 ~t"#{count} error(s)"N
 # with count = 1 => "1 error(s)"  (untranslated fallback)
 # with count = 3 => "3 error(s)"  (untranslated fallback)
+```
+
+```elixir
+~t"#{num} error(s)"N
+# with num = 1 => "1 error(s)"  (untranslated fallback)
+# with num = 3 => "3 error(s)"  (untranslated fallback)
+```
+
+```elixir
+# valid
+~t"#{id} #{count} error(s)"N
+
+# error
+~t"#{id} #{num} error(s)"N
 ```
 
 Under the hood, the sigil uses the same message as both `msgid` and `msgid_plural`:
@@ -211,7 +225,7 @@ You can use explicit key syntax to bind `count` to an arbitrary expression:
 ~t"#{count = length(users)} user(s)"N
 ```
 
-`count` must appear as a binding. Using `N` without a `count` binding raises an `ArgumentError`. Without the `N` modifier, the message is treated as a regular (non-plural) translation.
+When there is only one binding, any name works (e.g., `~t"#{num} error(s)"N`). With multiple bindings, one must be named `count`. Using `N` without any bindings raises an `ArgumentError`. Without the `N` modifier, the message is treated as a regular (non-plural) translation.
 
 The `N` modifier can be combined with other modifiers: `~t"#{count} error(s)"eN` uses the `errors` domain.
 

--- a/lib/gettext_sigils/pluralization.ex
+++ b/lib/gettext_sigils/pluralization.ex
@@ -26,28 +26,23 @@ defmodule GettextSigils.Pluralization do
   @type plural() :: {binary(), binary(), Macro.t(), Keyword.t()}
 
   @spec pluralize!(singular()) :: plural()
+  def pluralize!({_msgid, []}) do
+    raise ArgumentError,
+          "plural message requires at least one binding for the count"
+  end
+
+  def pluralize!({msgid, [{_key, value}]}) do
+    {msgid, msgid, value, []}
+  end
+
   def pluralize!({msgid, bindings}) do
-    {count, remaining} = extract_count!(bindings)
-    {msgid, msgid, count, remaining}
-  end
-
-  defp extract_count!([{_key, value}]) do
-    {value, []}
-  end
-
-  defp extract_count!(bindings) when length(bindings) > 1 do
     case Keyword.pop(bindings, :count) do
       {nil, _} ->
         raise ArgumentError,
               "plural message with multiple bindings requires a \"count\" binding to identify the pluralizer"
 
       {count, remaining} ->
-        {count, remaining}
+        {msgid, msgid, count, remaining}
     end
-  end
-
-  defp extract_count!([]) do
-    raise ArgumentError,
-          "plural message requires at least one binding for the count"
   end
 end

--- a/lib/gettext_sigils/pluralization.ex
+++ b/lib/gettext_sigils/pluralization.ex
@@ -28,14 +28,23 @@ defmodule GettextSigils.Pluralization do
     {msgid, msgid, count, remaining}
   end
 
-  defp extract_count!(bindings) do
+  defp extract_count!([{_key, value}]) do
+    {value, []}
+  end
+
+  defp extract_count!(bindings) when length(bindings) > 1 do
     case Keyword.pop(bindings, :count) do
       {nil, _} ->
         raise ArgumentError,
-              "plural message requires a \"count\" binding, but none was found"
+              "plural message with multiple bindings requires a \"count\" binding to identify the pluralizer"
 
       {count, remaining} ->
         {count, remaining}
     end
+  end
+
+  defp extract_count!([]) do
+    raise ArgumentError,
+          "plural message requires at least one binding for the count"
   end
 end

--- a/lib/gettext_sigils/pluralization.ex
+++ b/lib/gettext_sigils/pluralization.ex
@@ -3,8 +3,11 @@ defmodule GettextSigils.Pluralization do
   Handles pluralization for the `~t` sigil's `N` modifier.
 
   When the `N` modifier is present, the message is used as both `msgid` and
-  `msgid_plural`, and the `:count` binding is extracted as the `n` argument
+  `msgid_plural`, and a binding is extracted as the `n` argument
   to `dpngettext/6`.
+
+  If the message has a single binding, it is used as the count regardless of
+  its name. If there are multiple bindings, one must be named `:count`.
 
   ## Examples
 

--- a/test/gettext_sigils/heex_test.exs
+++ b/test/gettext_sigils/heex_test.exs
@@ -50,10 +50,10 @@ defmodule GettextSigils.HEExTest do
 
       html =
         rendered_to_string(~H"""
-        <h1>{~t"#{count = length(@todos)} todos(s)"N}</h1>
+        <h1>{~t"#{count = length(@todos)} todo(s)"N}</h1>
         """)
 
-      assert html =~ "3 todos(s)"
+      assert html =~ "3 todo(s)"
     end
   end
 end

--- a/test/gettext_sigils/pluralization_test.exs
+++ b/test/gettext_sigils/pluralization_test.exs
@@ -32,9 +32,20 @@ defmodule GettextSigils.PluralizationTest do
              {"%{count} user(s)", "%{count} user(s)", 3, []}
   end
 
-  test "raises when count binding is missing" do
-    assert_raise ArgumentError, ~r/requires a "count" binding/, fn ->
+  test "raises when no bindings are present" do
+    assert_raise ArgumentError, ~r/requires at least one binding/, fn ->
       Pluralization.pluralize!({"no count here", []})
+    end
+  end
+
+  test "single binding with any name is used as count" do
+    assert Pluralization.pluralize!({"%{num} error(s)", [num: 5]}) ==
+             {"%{num} error(s)", "%{num} error(s)", 5, []}
+  end
+
+  test "multiple bindings require count key" do
+    assert_raise ArgumentError, ~r/requires a "count" binding/, fn ->
+      Pluralization.pluralize!({"%{num} %{name} error(s)", [num: 5, name: "validation"]})
     end
   end
 end

--- a/test/gettext_sigils_test.exs
+++ b/test/gettext_sigils_test.exs
@@ -21,7 +21,7 @@ defmodule GettextSigilsTest do
       assert ~t[with #{"interpolation"}]em == "errors/MyModule: with interpolation"
     end
 
-    test "imports Gettext marcros" do
+    test "imports Gettext macros" do
       assert gettext("Hello, Gettext!") == "default: Hello, Gettext!"
     end
   end

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -74,7 +74,8 @@ Use the `N` modifier for pluralization. The same message is used as both `msgid`
 # => dpngettext("default", nil, "%{count} item(s)", "%{count} item(s)", count)
 ```
 
-- `count` must appear as a binding
+- With a single binding, any name works as the count (e.g., `~t"#{num} item(s)"N`)
+- With multiple bindings, one must be named `count`
 - Bind `count` to an arbitrary expression with explicit key syntax: `#{count = length(users)}`
 - Combine with other modifiers: `~t"#{count} error(s)"eN` (uses `errors` domain)
 - Translators provide distinct singular/plural forms in `.po` files


### PR DESCRIPTION
1. allows for a plural binding that isn't "count" in the single binding case. I think this will make it easier for people who are already using gettext and want to convert.

i.e: `~t"I have #{num} apples"`

2. fixes 2 typos.

👋 if using "count" as the binding is something you want to stick by then feel free to disregard this PR.