### PR TITLE
Remove rogue debug logs

### DIFF
--- a/lib/mix/tasks/gettext_sigils.install.ex
+++ b/lib/mix/tasks/gettext_sigils.install.ex
@@ -125,8 +125,6 @@ if Code.ensure_loaded?(Igniter) do
     end
   end
 else
-  IO.puts("TETEST")
-
   defmodule Mix.Tasks.GettextSigils.Install do
     @shortdoc "#{__MODULE__.Docs.short_doc()} | Install `igniter` to use"
 


### PR DESCRIPTION
The changes remove an unintentional debug logs from the library tasks 😅

They appear during compilation:

```txt
==> gettext_sigils
Compiling 9 files (.ex)
TETEST
Generated gettext_sigils app
```